### PR TITLE
Ignored Interface Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.2.2 (Unreleased)
+
+NOTES:
+
+* Remove reflective mapping of workload objects in favour of splitting managed/unmanaged model mapping
+
+BUG FIXES:
+
+* Fix `ignored_interface_names` parameter to be editable for `managed_workload` resources
+
 ## 0.2.1 (May 17, 2022)
 
 NOTES:

--- a/docs/resources/managed_workload.md
+++ b/docs/resources/managed_workload.md
@@ -71,6 +71,7 @@ resource "illumio-core_managed_workload" "aws_host1" {
 - `enforcement_mode` (String) Enforcement mode of workload(s) to return. Allowed values for enforcement modes are "idle","visibility_only","full", and "selective". Default value: "visibility_only"
 - `external_data_reference` (String) Unique identifier for the workload in the external data source
 - `external_data_set` (String) The data source from which a resource originates
+- `ignored_interface_names` (List of String) Workload interface names to ignore (e.g. `eth0`). Ignored interfaces will not be included in policy configuration provided by the PCE.
 - `labels` (Block Set) Assigned labels for workload (see [below for nested schema](#nestedblock--labels))
 - `service_principal_name` (String) The Kerberos Service Principal Name (SPN). The SPN should be between 1 to 255 characters
 - `service_provider` (String) Service provider for Workload. The service_provider should be up to 255 characters
@@ -94,7 +95,6 @@ resource "illumio-core_managed_workload" "aws_host1" {
 - `distinguished_name` (String) X.509 Subject distinguished name.
 - `firewall_coexistence` (List of Object) Firewall coexistence mode for Workload (see [below for nested schema](#nestedatt--firewall_coexistence))
 - `href` (String) URI of the Workload
-- `ignored_interface_names` (List of String) Ignored Interface Names for Workload
 - `ike_authentication_certificate` (Map of String) IKE authentication certificate for certificate-based Secure Connect and Machine Auth
 - `os_detail` (String) Additional OS details - just displayed to end-user. Set by the VEN.
 - `os_id` (String) OS identifier for Workload. Set by the VEN.

--- a/illumio-core/resource_illumio_workload.go
+++ b/illumio-core/resource_illumio_workload.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/illumio/terraform-provider-illumio-core/models"
 )
 
 func resourceIllumioWorkload() *schema.Resource {
@@ -520,9 +519,7 @@ func resourceIllumioWorkloadCreate(ctx context.Context, d *schema.ResourceData, 
 	illumioClient := pConfig.IllumioClient
 
 	orgID := illumioClient.OrgID
-
-	workload := &models.Workload{}
-	populateWorkloadFromResourceData(workload, d)
+	workload := populateUnmanagedWorkloadFromResourceData(d)
 
 	_, data, err := illumioClient.Create(fmt.Sprintf("/orgs/%d/workloads", orgID), workload)
 	if err != nil {
@@ -726,9 +723,7 @@ func resourceIllumioWorkloadUpdate(ctx context.Context, d *schema.ResourceData, 
 	illumioClient := pConfig.IllumioClient
 
 	var diags diag.Diagnostics
-
-	workload := &models.Workload{}
-	populateWorkloadFromResourceData(workload, d)
+	workload := populateUnmanagedWorkloadFromResourceData(d)
 
 	if diags.HasError() {
 		return diags

--- a/models/workload.go
+++ b/models/workload.go
@@ -66,8 +66,9 @@ type Workload struct {
 	// boolean false is omitted with `omitempty` when marshalling; use a pointer to fix this behaviour
 	Online *bool `json:"online,omitempty"`
 
-	// don't omitempty for labels - an empty array should remove all labels from the workload
-	Labels []Href `json:"labels"`
+	// don't omitempty for lists - an empty array should remove all objects from the workload
+	IgnoredInterfaceNames []string `json:"ignored_interface_names"`
+	Labels                []Href   `json:"labels"`
 }
 
 // ToMap - Returns map for Workload model


### PR DESCRIPTION
* remove reflective mapping of workload objects in favour of splitting managed/unmanaged model mapping
* add ignored_interface_names as optional param for managed workloads
