### PR TITLE
Fix: Allow VRRP Proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=illumio-core
 
+TEST_PARALLELISM?=4
 
 default: build
 
-tools: 
+tools:
 	go mod vendor
 
 build: fmtcheck
@@ -18,7 +19,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -parallel=$(TEST_PARALLELISM) -timeout 120m
 
 vet:
 	@echo "go vet ."

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -28,7 +28,7 @@ data "illumio-core_services" "example" {}
 - `max_results` (String) Maximum number of Services to return. The integer should be a non-zero positive integer
 - `name` (String) Name of the Service (does not need to be unique)
 - `port` (String) Specify port or port range to filter results. The range is from -1 to 65535 (0 is not supported)
-- `proto` (String) Protocol to filter on. Allowed values are -1, 1, 2, 4, 6, 17, 47, 58 and 94
+- `proto` (String) Protocol to filter on. IANA protocol numbers between 0-255 are permitted, and -1 represents all services
 - `pversion` (String) pversion of the security policy. Allowed values are "draft", "active", and numbers greater than 0. Default value: "draft"
 
 ### Read-Only

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -79,7 +79,7 @@ resource "illumio-core_service" "win_example" {
 
 Required:
 
-- `proto` (String) Transport protocol. Allowed values are -1, 1, 2, 4, 6, 17, 47, 58 and 94
+- `proto` (String) Transport protocol. IANA protocol numbers between 0-255 are permitted, and -1 represents all services
 
 Optional:
 
@@ -98,6 +98,6 @@ Optional:
 - `icmp_type` (String) ICMP Type. Allowed when proto is 1 (ICMP) or 58 (ICMPv6). Allowed range is 0 - 255
 - `port` (String) Port Number. Also, the starting port when specifying a range. Allowed when value of proto is 6 or 17. Allowed range is 0 - 65535
 - `process_name` (String) Name of running process
-- `proto` (String) Transport protocol. Allowed values are -1, 1, 2, 4, 6, 17, 47, 58 and 94
+- `proto` (String) Transport protocol. IANA protocol numbers between 0-255 are permitted, and -1 represents all services.
 - `service_name` (String) Name of Windows Service
 - `to_port` (String) High end of port range if specifying a range. Allowed range is 0 - 65535

--- a/illumio-core/data_source_illumio_services.go
+++ b/illumio-core/data_source_illumio_services.go
@@ -110,8 +110,8 @@ func datasourceIllumioServices() *schema.Resource {
 			"proto": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				Description:      "Protocol to filter on. Allowed values are -1, 1, 2, 4, 6, 17, 47, 58 and 94",
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validServiceProtos, false)),
+				Description:      "Protocol to filter on. IANA protocol numbers between 0-255 are permitted, and -1 represents all services.",
+				ValidateDiagFunc: isStringInRange(-1, 255),
 			},
 			"items": {
 				Type:        schema.TypeList,

--- a/illumio-core/data_source_illumio_workload.go
+++ b/illumio-core/data_source_illumio_workload.go
@@ -388,13 +388,13 @@ func datasourceIllumioWorkload() *schema.Resource {
 										Description: "Transport protocol for open service ports",
 									},
 									"address": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
 										Description: "	The local address this service is bound to",
 									},
 									"port": {
-										Type:     schema.TypeInt,
-										Computed: true,
+										Type:        schema.TypeInt,
+										Computed:    true,
 										Description: "	The local port this service is bound to",
 									},
 									"process_name": {

--- a/illumio-core/data_source_illumio_workload_interfaces.go
+++ b/illumio-core/data_source_illumio_workload_interfaces.go
@@ -39,8 +39,8 @@ func datasourceIllumioWorkloadInterfaces() *schema.Resource {
 							Description: "Link State for Workload Interface",
 						},
 						"address": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
 							Description: "The IP Address to assign to this interface				",
 						},
 						"cidr_block": {

--- a/illumio-core/data_source_illumio_workloads.go
+++ b/illumio-core/data_source_illumio_workloads.go
@@ -396,13 +396,13 @@ func datasourceIllumioWorkloads() *schema.Resource {
 													Description: "Transport protocol for open service ports",
 												},
 												"address": {
-													Type:     schema.TypeString,
-													Computed: true,
+													Type:        schema.TypeString,
+													Computed:    true,
 													Description: "	The local address this service is bound to",
 												},
 												"port": {
-													Type:     schema.TypeInt,
-													Computed: true,
+													Type:        schema.TypeInt,
+													Computed:    true,
 													Description: "	The local port this service is bound to",
 												},
 												"process_name": {

--- a/illumio-core/resource_illumio_service.go
+++ b/illumio-core/resource_illumio_service.go
@@ -13,10 +13,6 @@ import (
 	"github.com/illumio/terraform-provider-illumio-core/models"
 )
 
-var (
-	validServiceProtos = []string{"-1", "1", "2", "4", "6", "17", "47", "58", "94"}
-)
-
 func resourceIllumioService() *schema.Resource {
 	return &schema.Resource{
 		ReadContext:   resourceIllumioServiceRead,
@@ -74,8 +70,8 @@ func resourceIllumioService() *schema.Resource {
 						"proto": {
 							Type:             schema.TypeString,
 							Required:         true,
-							Description:      `Transport protocol. Allowed values are -1, 1, 2, 4, 6, 17, 47, 58 and 94`,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validServiceProtos, false)),
+							Description:      `Transport protocol. IANA protocol numbers between 0-255 are permitted, and -1 represents all services.`,
+							ValidateDiagFunc: isStringInRange(-1, 255),
 						},
 						"icmp_type": {
 							Type:             schema.TypeString,
@@ -126,8 +122,8 @@ func resourceIllumioService() *schema.Resource {
 						"proto": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							Description:      `Transport protocol. Allowed values are -1, 1, 2, 4, 6, 17, 47, 58 and 94`,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validServiceProtos, false)),
+							Description:      `Transport protocol. IANA protocol numbers between 0-255 are permitted, and -1 represents all services.`,
+							ValidateDiagFunc: isStringInRange(-1, 255),
 						},
 						"icmp_type": {
 							Type:             schema.TypeString,


### PR DESCRIPTION
Allow VRRP services to be created through the provider.

Relevant KB article: https://support.illumio.com/knowledge-base/articles/How-to-resolve-Blocked-Traffic-for-the-VRRP-Protocol.html

* remove list constraint for valid protocol numbers in `illumio-core_service` resource; replace with int -1 <= N <= 255 constraint
* set default test parallelism to 4 in `make testacc` to avoid timeouts