### PR TITLE
Fix #36 - managed_workload update failure

### DIFF
--- a/illumio-core/resource_illumio_workload_managed.go
+++ b/illumio-core/resource_illumio_workload_managed.go
@@ -591,8 +591,8 @@ func resourceIllumioManagedWorkloadUpdate(ctx context.Context, d *schema.Resourc
 		ExternalDataSet:       d.Get("external_data_set").(string),
 		ServicePrincipalName:  d.Get("service_principal_name").(string),
 		ServiceProvider:       d.Get("service_provider").(string),
-		Labels:                labels,
-		IgnoredInterfaceNames: ignoredInterfaceNames,
+		Labels:                &labels,
+		IgnoredInterfaceNames: &ignoredInterfaceNames,
 	}
 
 	if diags.HasError() {

--- a/illumio-core/resource_illumio_workload_unmanaged.go
+++ b/illumio-core/resource_illumio_workload_unmanaged.go
@@ -891,9 +891,9 @@ func populateUnmanagedWorkloadFromResourceData(d *schema.ResourceData) *models.W
 		PublicIP:                              d.Get("public_ip").(string),
 		ServicePrincipalName:                  d.Get("service_principal_name").(string),
 		ServiceProvider:                       d.Get("service_provider").(string),
-		Labels:                                labels,
-		Interfaces:                            interfaces,
-		IgnoredInterfaceNames:                 ignoredInterfaceNames,
+		Labels:                                &labels,
+		Interfaces:                            &interfaces,
+		IgnoredInterfaceNames:                 &ignoredInterfaceNames,
 	}
 }
 

--- a/models/workload.go
+++ b/models/workload.go
@@ -23,9 +23,9 @@ type Workload struct {
 	Online *bool `json:"online,omitempty"`
 
 	// don't omitempty for lists - an empty array should remove all objects from the workload
-	IgnoredInterfaceNames []string                 `json:"ignored_interface_names"`
-	Labels                []*LabelOptionalKeyValue `json:"labels"`
-	Interfaces            []*WorkloadInterface     `json:"interfaces"`
+	IgnoredInterfaceNames *[]string                 `json:"ignored_interface_names,omitempty"`
+	Labels                *[]*LabelOptionalKeyValue `json:"labels,omitempty"`
+	Interfaces            *[]*WorkloadInterface     `json:"interfaces,omitempty"`
 }
 
 // ToMap - Returns map for Workload model


### PR DESCRIPTION
Fixes managed workload updates failing with 406 due to empty `interfaces` field included in the PUT.

* change workload model slices to pointers so they're properly omitted from request payloads when empty