### PR TITLE
Recreate Objects Flagged as Deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.1.3 (TBD)
+
+BUG FIXES:
+
+* update client to not pass an error back if a DELETE returns a 406 `already-deleted` response
+
+ENHANCEMENTS:
+
+* set `ForceNew` on the deleted flag for the following resources and add customizers to ensure a remote deletion prompts Terraform to recreate the resource
+    * `illumio-core_label`
+    * `illumio-core_label_type`
+    * `illumio-core_unmanaged_workload`
+
 ## 1.1.2 (Apr 5, 2023)
 
 BUG FIXES:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,8 +4,11 @@ package client
 
 import (
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"golang.org/x/time/rate"
@@ -67,5 +70,83 @@ func TestGet(t *testing.T) {
 	_, _, err = testClient.Get("/health", nil)
 	if err != nil {
 		t.Error("Error in fetching health")
+	}
+}
+
+func TestExpectedHTTPErrors(t *testing.T) {
+	endpoint := "/health"
+
+	tests := []struct {
+		httpStatus    int
+		expectedError string
+	}{
+		{http.StatusBadRequest, "failed: status code: 400"},
+		{http.StatusUnauthorized, "unauthorized"},
+		{http.StatusForbidden, "forbidden"},
+		{http.StatusTooManyRequests, "max retries exceeded"},
+		{http.StatusBadGateway, "server-error"},
+		{http.StatusServiceUnavailable, "server-error"},
+		{http.StatusInternalServerError, "server-error"},
+		{http.StatusPermanentRedirect, "failed: status code: 308"},
+	}
+
+	for _, tt := range tests {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tt.httpStatus)
+		}))
+		defer server.Close()
+
+		apiClient, err := NewV2(
+			server.URL, 1, "api_key", "api_secret",
+			30, rate.NewLimiter(rate.Limit(float64(125)/float64(60)), 1),
+			10, 0, false, "", "", "",
+		)
+		if err != nil {
+			t.Fatalf("V2.New() => failed to create client: %v", err)
+		}
+		_, _, err = apiClient.Get(endpoint, nil)
+
+		if err == nil {
+			t.Errorf("V2.Get(%q, nil) => returned error was nil, want %q", endpoint, tt.expectedError)
+		}
+
+		if !strings.Contains(err.Error(), tt.expectedError) {
+			t.Errorf("V2.Get(%q, nil) => error was %q, want %q", endpoint, err.Error(), tt.expectedError)
+		}
+	}
+}
+
+func TestDelete(t *testing.T) {
+	href := "/orgs/1/labels/1"
+
+	tests := []struct {
+		httpStatus      int
+		responseContent string
+	}{
+		{http.StatusNoContent, ""},
+		{http.StatusNotAcceptable, `{"token": "label_already_deleted", "message": "Cannot delete a label that has already been deleted"}`},
+	}
+
+	for _, tt := range tests {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(tt.responseContent))
+			w.WriteHeader(tt.httpStatus)
+		}))
+		defer server.Close()
+
+		apiClient, err := NewV2(
+			server.URL, 1, "api_key", "api_secret",
+			30, rate.NewLimiter(rate.Limit(float64(125)/float64(60)), 1),
+			10, 0, false, "", "", "",
+		)
+		if err != nil {
+			t.Fatalf("V2.New() => failed to create client: %v", err)
+		}
+		_, err = apiClient.Delete(href)
+
+		if err != nil {
+			t.Errorf("V2.Delete(%q) => returned unexpected error %v", href, err)
+		}
 	}
 }

--- a/illumio-core/data_source_illumio_label_test.go
+++ b/illumio-core/data_source_illumio_label_test.go
@@ -44,19 +44,63 @@ func TestAccIllumioLabel_Read(t *testing.T) {
 	})
 }
 
-func testAccCheckIllumioLabelDataSourceConfig_basic() string {
-	rName1 := acctest.RandomWithPrefix(prefixLabel)
+func TestAccIllumioLabelResource_Delete(t *testing.T) {
+	labelHref := new(string)
+	newLabelHref := new(string)
+	resourceName := "illumio-core_label.label_test"
+	labelValue := acctest.RandomWithPrefix(prefixLabel)
 
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIllumioLabelResourceConfig_basic(labelValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(resourceName, labelHref),
+					resource.TestCheckResourceAttr(resourceName, "key", "app"),
+					resource.TestCheckResourceAttr(resourceName, "value", labelValue),
+				),
+			},
+			{
+				// check that an apply called after a label has been deleted
+				// correctly destroys and recreates the resource
+				PreConfig: deleteLabelFromPCE("app", labelValue, t),
+				Config:    testAccCheckIllumioLabelResourceConfig_basic(labelValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(resourceName, newLabelHref),
+					testAccCheckCompareRefs(labelHref, newLabelHref, false),
+					resource.TestCheckResourceAttr(resourceName, "key", "app"),
+					resource.TestCheckResourceAttr(resourceName, "value", labelValue),
+				),
+			},
+			{
+				// check that a destroy called after a label has been deleted
+				// doesn't throw an error
+				PreConfig: deleteLabelFromPCE("app", labelValue, t),
+				Destroy:   true,
+				Config:    testAccCheckIllumioLabelResourceConfig_basic(labelValue),
+			},
+		},
+	})
+}
+
+func testAccCheckIllumioLabelResourceConfig_basic(value string) string {
 	return fmt.Sprintf(`
 resource "illumio-core_label" "label_test" {
 	key   = "app"
 	value = %[1]q
 }
+`, value)
+}
 
+func testAccCheckIllumioLabelDataSourceConfig_basic() string {
+	labelValue := acctest.RandomWithPrefix(prefixLabel)
+
+	return testAccCheckIllumioLabelResourceConfig_basic(labelValue) + `
 data "illumio-core_label" "label_test" {
 	href = illumio-core_label.label_test.href
-}
-`, rName1)
+}`
 }
 
 func testAccCheckIllumioLabeResource_updateValue(updatedValue string) string {
@@ -66,4 +110,29 @@ resource "illumio-core_label" "label_test" {
 	value = %[1]q
 }
 `, updatedValue)
+}
+
+// deleteLabelFromPCE removes the label with the given key/value
+// via the API to test Terraform drift behaviour
+func deleteLabelFromPCE(key, value string, t *testing.T) func() {
+	return func() {
+		conf := TestAccProvider.Meta().(Config)
+		illumioClient := conf.IllumioClient
+
+		endpoint := fmt.Sprintf("/orgs/%d/labels", illumioClient.OrgID)
+		_, data, err := illumioClient.Get(endpoint, &map[string]string{
+			"key":   key,
+			"value": value,
+		})
+		if err != nil {
+			t.Fatal("Failed to get label from PCE")
+		}
+
+		href := data.S("0", "href").Data().(string)
+
+		_, err = illumioClient.Delete(href)
+		if err != nil {
+			t.Fatal("Failed to delete label from PCE")
+		}
+	}
 }

--- a/illumio-core/provider_test.go
+++ b/illumio-core/provider_test.go
@@ -96,6 +96,20 @@ func skipIfPCEVersionBelow(v string) func() (bool, error) {
 	}
 }
 
+// deleteFromPCE removes the label with the given HREF
+// via the API to test Terraform drift behaviour
+func deleteFromPCE(href *string, t *testing.T) func() {
+	return func() {
+		conf := TestAccProvider.Meta().(Config)
+		illumioClient := conf.IllumioClient
+
+		_, err := illumioClient.Delete(*href)
+		if err != nil {
+			t.Fatal("Failed to delete object with HREF " + *href + " from PCE")
+		}
+	}
+}
+
 // testAccCheckResourceExists checks if a resource exists and assigns
 // the corresponding HREF to the given pointer
 func testAccCheckResourceExists(n string, href *string) resource.TestCheckFunc {

--- a/illumio-core/provider_test.go
+++ b/illumio-core/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -92,5 +93,46 @@ func skipIfPCEVersionBelow(v string) func() (bool, error) {
 		}
 
 		return pceVersion.LessThan(checkVersion), nil
+	}
+}
+
+// testAccCheckResourceExists checks if a resource exists and assigns
+// the corresponding HREF to the given pointer
+func testAccCheckResourceExists(n string, href *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// find the corresponding state object
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		// retrieve the configured client from the test setup
+		conf := TestAccProvider.Meta().(Config)
+		illumioClient := conf.IllumioClient
+
+		_, data, err := illumioClient.Get(rs.Primary.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		ref := data.S("href").Data().(string)
+		*href = ref
+
+		return nil
+	}
+}
+
+// testAccCheckCompareRefs compares given HREFs
+// XXX: note that we have to pass the HREFs as pointers
+// as this function is run before the tests; the inner
+// function needs references to the refs that can be set
+// during the test
+func testAccCheckCompareRefs(origRef, newRef *string, shouldEqual bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if (origRef == newRef) == shouldEqual {
+			return nil
+		}
+
+		return fmt.Errorf("testAccCheckCompareRefs(%q, %q, %t) failed", *origRef, *newRef, shouldEqual)
 	}
 }

--- a/illumio-core/resource_illumio_label.go
+++ b/illumio-core/resource_illumio_label.go
@@ -96,12 +96,15 @@ func resourceIllumioLabel() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: customdiff.Sequence(
-			recreateDeletedLabel(),
+			recreateDeleted(),
 		),
 	}
 }
 
-func recreateDeletedLabel() schema.CustomizeDiffFunc {
+// recreateDeleted checks for changes to the resource's deleted flag, indicating
+// the object has been removed from the remote. If the flag is set, it prompts
+// a re-create of the resource.
+func recreateDeleted() schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, m any) error {
 		_, newDeletedVal := d.GetChange("deleted")
 		if newDeletedVal.(bool) == true {

--- a/illumio-core/resource_illumio_label_type.go
+++ b/illumio-core/resource_illumio_label_type.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/illumio/terraform-provider-illumio-core/models"
@@ -112,6 +113,7 @@ func resourceIllumioLabelType() *schema.Resource {
 			"deleted": {
 				Type:        schema.TypeBool,
 				Computed:    true,
+				ForceNew:    true,
 				Description: "Flag to indicate whether the label type has been deleted or not",
 			},
 			"created_at": {
@@ -165,6 +167,9 @@ func resourceIllumioLabelType() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: customdiff.Sequence(
+			recreateDeleted(),
+		),
 	}
 }
 

--- a/illumio-core/resource_illumio_workload_unmanaged.go
+++ b/illumio-core/resource_illumio_workload_unmanaged.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -30,6 +31,9 @@ func resourceIllumioUnmanagedWorkload() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: customdiff.Sequence(
+			recreateDeleted(),
+		),
 	}
 }
 
@@ -213,6 +217,7 @@ func unmanagedWorkloadSchema() map[string]*schema.Schema {
 		"deleted": {
 			Type:        schema.TypeBool,
 			Computed:    true,
+			ForceNew:    true,
 			Description: "This indicates that the workload has been deleted",
 		},
 		"agent_to_pce_certificate_authentication_id": {


### PR DESCRIPTION
Some objects in the PCE remain in the database after they are deleted, instead setting a `delete` flag on the object. To avoid Terraform errors when these objects are deleted out-of-band, use `ForceNew` to recreate the resource if `deleted=true` in the remote state.

* set `ForceNew` on the deleted flag for the following resources and add customizers to ensure a remote deletion prompts Terraform to recreate the resource
    * `illumio-core_label`
    * `illumio-core_label_type`
    * `illumio-core_unmanaged_workload`
* update client to not pass an error back if a DELETE returns a 406 `already-deleted` response
