### PR TITLE
Store Container Cluster Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ BUG FIXES:
 
 ENHANCEMENTS:
 
-* add `container_cluster_id` and `container_cluster_token` vars to `illumio-core_pairing_profile` resource
+* add `container_cluster_id` and `container_cluster_token` vars to `illumio-core_container_cluster` resource
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.1.4 (TBD)
+
+BUG FIXES:
+
+* Fix `illumio-core_pairing_profile` `agent_software_release` default to work when VEN library is not empty
+
+ENHANCEMENTS:
+
+* add `container_cluster_id` and `container_cluster_token` vars to `illumio-core_pairing_profile` resource
+    * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
+    * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
+
 ## 1.1.3 (Jun 21, 2023)
 
 BUG FIXES:

--- a/docs/data-sources/container_cluster.md
+++ b/docs/data-sources/container_cluster.md
@@ -33,6 +33,7 @@ data "illumio-core_container_cluster" "kube" {
 ### Read-Only
 
 - `caps` (List of String) User permissions for the object
+- `container_cluster_id` (String) Convenience variable for the cluster UUID contained in the HREF
 - `container_runtime` (String) The Container Runtime used in this Cluster
 - `description` (String) Description of the Cluster
 - `errors` (List of Object) Errors for Cluster (see [below for nested schema](#nestedatt--errors))

--- a/docs/data-sources/container_clusters.md
+++ b/docs/data-sources/container_clusters.md
@@ -57,6 +57,7 @@ data "illumio-core_container_clusters" "kube_clusters" {
 Read-Only:
 
 - `caps` (List of String) Permission types
+- `container_cluster_id` (String) Convenience variable for the cluster UUID contained in the HREF
 - `container_runtime` (String) The Container Runtime used in this Cluster
 - `description` (String) Description of the Cluster
 - `errors` (List of Object) Errors for Cluster (see [below for nested schema](#nestedobjatt--items--errors))

--- a/docs/resources/container_cluster.md
+++ b/docs/resources/container_cluster.md
@@ -30,6 +30,8 @@ resource "illumio-core_container_cluster" "example" {
 ### Read-Only
 
 - `caps` (List of String) User permissions for the object
+- `container_cluster_id` (String) Convenience variable for the cluster UUID contained in the HREF
+- `container_cluster_token` (String, Sensitive) The pairing token for the cluster. Only returned when a cluster is first created
 - `container_runtime` (String) The Container Runtime used in this Cluster
 - `errors` (List of Object) Errors for Cluster (see [below for nested schema](#nestedatt--errors))
 - `href` (String) URI of the Cluster

--- a/docs/resources/pairing_profile.md
+++ b/docs/resources/pairing_profile.md
@@ -61,7 +61,7 @@ resource "illumio-core_pairing_profile" "example" {
 
 ### Optional
 
-- `agent_software_release` (String) Agent software release associated with this paring profile. Default value: "Default ()"
+- `agent_software_release` (String) Agent software release associated with this paring profile
 - `allowed_uses_per_key` (String) The number of times pairing profile keys can be usedd. Allowed values are range(1-2147483647) and "unlimited". Default value: "unlimited"
 - `app_label_lock` (Boolean) Flag that controls whether app label can be overridden from pairing script. Default value: true
 - `description` (String) The long description of the pairing profile

--- a/illumio-core/data_source_illumio_container_cluster_test.go
+++ b/illumio-core/data_source_illumio_container_cluster_test.go
@@ -30,6 +30,8 @@ func TestAccIllumioCC_Read(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "manager_type", resourceName, "manager_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "online", resourceName, "online"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "container_cluster_id", resourceName, "container_cluster_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_cluster_token"),
 				),
 			},
 			{
@@ -40,9 +42,10 @@ func TestAccIllumioCC_Read(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"container_cluster_token"},
 			},
 		},
 	})

--- a/illumio-core/data_source_illumio_container_clusters.go
+++ b/illumio-core/data_source_illumio_container_clusters.go
@@ -120,6 +120,11 @@ func datasourceIllumioContainerClusters() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"container_cluster_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Convenience variable for the cluster UUID contained in the HREF",
+						},
 					},
 				},
 			},
@@ -175,6 +180,7 @@ func datasourceIllumioContainerClustersRead(ctx context.Context, d *schema.Resou
 
 	for _, child := range data.Children() {
 		m := extractMap(child, keys)
+		m["container_cluster_id"] = getIDFromHref(m["href"].(string))
 
 		for key, value := range map[string][]string{
 			"nodes":  {"pod_subnet"},

--- a/illumio-core/data_source_illumio_rule_sets.go
+++ b/illumio-core/data_source_illumio_rule_sets.go
@@ -356,7 +356,7 @@ func datasourceIllumioRuleSetsRead(ctx context.Context, d *schema.ResourceData, 
 
 		key := "rules"
 		if ruleSet.Exists(key) {
-			rs[key] = extractRules(data.S("rules"))
+			rs[key] = extractRules(data.S(key))
 		}
 
 		key = "scopes"

--- a/illumio-core/data_source_illumio_workload_settings_test.go
+++ b/illumio-core/data_source_illumio_workload_settings_test.go
@@ -112,13 +112,19 @@ func testAccCheckIllumioWSResource_valueSet(resourceName, venType, setting, expe
 
 		for i := 0; i < settingCount; i++ {
 			key := fmt.Sprintf("%s.%d", setting, i)
-			if rs.Primary.Attributes[key+".ven_type"] == venType {
-				value := rs.Primary.Attributes[key+".value"]
-				if value != expectedValue {
-					return fmt.Errorf(`Attribute '%s' expected "%s" got "%s"`, key+".value", expectedValue, value)
-				}
 
-				return nil
+			if vt, ok := rs.Primary.Attributes[key+".ven_type"]; ok {
+				// PCE versions before 23.1 don't have the ven_type field
+				// so if it's empty, just check the value. otherwise,
+				// only check the value if the ven_type matches what we expect
+				if vt == "" || vt == venType {
+					value := rs.Primary.Attributes[key+".value"]
+					if value != expectedValue {
+						return fmt.Errorf(`Attribute '%s' expected "%s" got "%s"`, key+".value", expectedValue, value)
+					}
+
+					return nil
+				}
 			}
 		}
 

--- a/illumio-core/resource_illumio_pairing_profile.go
+++ b/illumio-core/resource_illumio_pairing_profile.go
@@ -154,8 +154,8 @@ func resourceIllumioPairingProfile() *schema.Resource {
 			"agent_software_release": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `Agent software release associated with this paring profile. Default value: "Default ()"`,
-				Default:     "Default ()",
+				Computed:    true,
+				Description: `Agent software release associated with this paring profile`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,

--- a/illumio-core/utils.go
+++ b/illumio-core/utils.go
@@ -192,6 +192,12 @@ func getParentHref(href string) string {
 	return re.FindString(href)
 }
 
+// Returns the object UUID from the end of an HREF
+func getIDFromHref(href string) string {
+	hrefParts := strings.Split(href, "/")
+	return hrefParts[len(hrefParts)-1]
+}
+
 // Returns string list from interface type
 func getStringList(o interface{}) []string {
 	i := o.([]interface{})


### PR DESCRIPTION
* fix `illumio-core_pairing_profile` `agent_software_release` default to work when VEN library is not empty

* add `container_cluster_id` and `container_cluster_token` vars to `illumio-core_container_cluster` resource