### PR TITLE
Fix #46 - add match_type parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ ENHANCEMENTS:
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` optional parameter allowing users to specify exact or partial name matching to the following data sources:
     * `illumio-core_rule_sets`
-    * `illumio-core_workloads`
+    * `illumio-core_vens`
     * `illumio-core_virtual_services`
+    * `illumio-core_workloads`
 
 ## 1.1.3 (Jun 21, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_ip_lists`
     * `illumio-core_label_groups`
     * `illumio-core_label_types`
     * `illumio-core_labels`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_label_types`
     * `illumio-core_labels`
     * `illumio-core_pairing_profiles`
     * `illumio-core_rule_sets`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_label_groups`
     * `illumio-core_label_types`
     * `illumio-core_labels`
     * `illumio-core_pairing_profiles`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ENHANCEMENTS:
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` optional parameter allowing users to specify exact or partial name matching to the following data sources:
     * `illumio-core_rule_sets`
+    * `illumio-core_services`
     * `illumio-core_vens`
     * `illumio-core_virtual_services`
     * `illumio-core_workloads`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ENHANCEMENTS:
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` optional parameter allowing users to specify exact or partial name matching to the following data sources:
     * `illumio-core_rule_sets`
+    * `illumio-core_workloads`
 
 ## 1.1.3 (Jun 21, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 BUG FIXES:
 
 * Fix `illumio-core_pairing_profile` `agent_software_release` default to work when VEN library is not empty
+* Fix `illumio-core_ip_list` resource to work properly when `ip_ranges` or `fqdns` blocks are not specified or removed from an existing resource
 
 ENHANCEMENTS:
 
 * add `container_cluster_id` and `container_cluster_token` vars to `illumio-core_container_cluster` resource
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
+* add `match_type` optional parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_rule_sets`
 
 ## 1.1.3 (Jun 21, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ ENHANCEMENTS:
 * add `container_cluster_id` and `container_cluster_token` vars to `illumio-core_container_cluster` resource
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
-* add `match_type` optional parameter allowing users to specify exact or partial name matching to the following data sources:
+* add `match_type` parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_labels`
     * `illumio-core_pairing_profiles`
     * `illumio-core_rule_sets`
     * `illumio-core_services`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ENHANCEMENTS:
 * add `match_type` optional parameter allowing users to specify exact or partial name matching to the following data sources:
     * `illumio-core_rule_sets`
     * `illumio-core_workloads`
+    * `illumio-core_virtual_services`
 
 ## 1.1.3 (Jun 21, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` optional parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_pairing_profiles`
     * `illumio-core_rule_sets`
     * `illumio-core_services`
     * `illumio-core_vens`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_enforcement_boundaries`
     * `illumio-core_ip_lists`
     * `illumio-core_label_groups`
     * `illumio-core_label_types`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_container_cluster_workload_profiles`
     * `illumio-core_container_clusters`
     * `illumio-core_enforcement_boundaries`
     * `illumio-core_ip_lists`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
     * `container_cluster_id` is a convenience var containing the cluster UUID (also present in the HREF)
     * `container_cluster_token` is only returned when the resource is first created and is needed to pair with the remote container cluster
 * add `match_type` parameter allowing users to specify exact or partial name matching to the following data sources:
+    * `illumio-core_container_clusters`
     * `illumio-core_enforcement_boundaries`
     * `illumio-core_ip_lists`
     * `illumio-core_label_groups`

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -parallel=$(TEST_PARALLELISM) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -parallel=$(TEST_PARALLELISM) -timeout 120m -sweep=all
 
 vet:
 	@echo "go vet ."

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,13 @@ test: fmtcheck
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
-testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -parallel=$(TEST_PARALLELISM) -timeout 120m -sweep=all
+testacc: fmtcheck _testacc sweep
+
+_testacc:
+	-TF_ACC=1 go test $(TEST) -v $(TESTARGS) -parallel=$(TEST_PARALLELISM) -timeout 120m
+
+sweep:
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -sweep=all
 
 vet:
 	@echo "go vet ."
@@ -74,4 +79,4 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile docs website website-test tools
+.PHONY: build test testacc _testacc sweep vet fmt fmtcheck errcheck vendor-status test-compile docs website website-test tools

--- a/docs/data-sources/container_cluster_workload_profile.md
+++ b/docs/data-sources/container_cluster_workload_profile.md
@@ -68,6 +68,7 @@ data "illumio-core_container_cluster_workload_profile" "kube_core_services" {
 - `labels` (List of Object) Labels to assign to the workload that matches the namespace (see [below for nested schema](#nestedatt--labels))
 - `linked` (Boolean) True if the namespace exists in the cluster and is reported by Kubelink
 - `managed` (Boolean) If the namespace is managed or not
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `name` (String) A friendly name given to a profile if the namespace is not user-friendly
 - `namespace` (String) Namespace name of the container workload profile
 - `updated_at` (String) Timestamp when this label group was last updated

--- a/docs/data-sources/container_clusters.md
+++ b/docs/data-sources/container_clusters.md
@@ -43,6 +43,7 @@ data "illumio-core_container_clusters" "kube_clusters" {
 
 ### Optional
 
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of container clusters to return. The integer should be a non-zero positive integer
 - `name` (String) Name of the container cluster(s) to return. Supports partial matches
 

--- a/docs/data-sources/enforcement_boundaries.md
+++ b/docs/data-sources/enforcement_boundaries.md
@@ -106,6 +106,7 @@ data "illumio-core_enforcement_boundaries" "block_windows_services" {
 ### Optional
 
 - `labels` (String) List of lists of label URIs, encoded as a JSON string
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of enforcement boundaries to return. The integer should be a non-zero positive integer
 - `name` (String) Filter by name supports partial matching
 - `pversion` (String) pversion of the security policy. Allowed values are "draft", "active", and numbers greater than 0. Default value: "draft"

--- a/docs/data-sources/ip_lists.md
+++ b/docs/data-sources/ip_lists.md
@@ -102,6 +102,7 @@ data "illumio-core_ip_lists" "aws_vpc" {
 - `external_data_set` (String) The data source from which a resource originates
 - `fqdn` (String) IP lists matching FQDN. Supports partial matches
 - `ip_address` (String) IP address matching IP list(s) to return. Supports partial matches
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of IP Lists to return. The integer should be a non-zero positive integer
 - `name` (String) Name of IP list(s) to return. Supports partial matches
 - `pversion` (String) pversion of the security policy. Allowed values are "draft", "active", and numbers greater than 0. Default value: "draft"

--- a/docs/data-sources/label_groups.md
+++ b/docs/data-sources/label_groups.md
@@ -86,6 +86,7 @@ data "illumio-core_label_groups" "env_groups" {
 - `external_data_reference` (String) A unique identifier within the external data source
 - `external_data_set` (String) The data source from which a resource originates
 - `key` (String) Key in key-value pair of contained labels or label groups. The value must be a string between 1 and 64 characters long
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Labels to return. The integer should be a non-zero positive integer
 - `name` (String) Name of Label Group(s) to return. Supports partial matches
 - `pversion` (String) pversion of the security policy. Allowed values are "draft", "active", and numbers greater than 0. Default value: "draft"

--- a/docs/data-sources/label_types.md
+++ b/docs/data-sources/label_types.md
@@ -50,7 +50,7 @@ data "illumio-core_label_types" "example" {
 - `external_data_set` (String) The data source from which a resource originates
 - `include_deleted` (String) Include deleted labels
 - `key` (String) Label type key to filter by. The value must be a string between 1 and 64 characters long
-- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
+- `match_type` (String) Indicates whether to return all partially-matching display names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Labels to return. The integer should be a non-zero positive integer
 
 ### Read-Only

--- a/docs/data-sources/label_types.md
+++ b/docs/data-sources/label_types.md
@@ -50,6 +50,7 @@ data "illumio-core_label_types" "example" {
 - `external_data_set` (String) The data source from which a resource originates
 - `include_deleted` (String) Include deleted labels
 - `key` (String) Label type key to filter by. The value must be a string between 1 and 64 characters long
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Labels to return. The integer should be a non-zero positive integer
 
 ### Read-Only

--- a/docs/data-sources/labels.md
+++ b/docs/data-sources/labels.md
@@ -51,6 +51,7 @@ data "illumio-core_labels" "loc_cloud" {
 - `external_data_set` (String) The data source from which a resource originates
 - `include_deleted` (String) Include deleted labels
 - `key` (String) Key in key-value pair. The value must be a string between 1 and 64 characters long
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Labels to return. The integer should be a non-zero positive integer
 - `usage` (String) Include label usage flags as well
 - `value` (String) Value on which to filter. Supports partial matches

--- a/docs/data-sources/labels.md
+++ b/docs/data-sources/labels.md
@@ -51,7 +51,7 @@ data "illumio-core_labels" "loc_cloud" {
 - `external_data_set` (String) The data source from which a resource originates
 - `include_deleted` (String) Include deleted labels
 - `key` (String) Key in key-value pair. The value must be a string between 1 and 64 characters long
-- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
+- `match_type` (String) Indicates whether to return all partially-matching label values or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Labels to return. The integer should be a non-zero positive integer
 - `usage` (String) Include label usage flags as well
 - `value` (String) Value on which to filter. Supports partial matches

--- a/docs/data-sources/pairing_profiles.md
+++ b/docs/data-sources/pairing_profiles.md
@@ -113,6 +113,7 @@ data "illumio-core_pairing_profiles" "dev" {
 - `external_data_reference` (String) A unique identifier within the external data source
 - `external_data_set` (String) The data source from which a resource originates
 - `labels` (String) List of lists of label URIs, encoded as a JSON string
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Pairing Profiles to return. The integer should be a non-zero positive integer
 - `name` (String) Name of Pairing Profile(s) to return. Supports partial matches
 

--- a/docs/data-sources/rule_sets.md
+++ b/docs/data-sources/rule_sets.md
@@ -78,6 +78,7 @@ data "illumio-core_rule_sets" "core_services" {
 - `external_data_reference` (String) A unique identifier within the external data source
 - `external_data_set` (String) The data source from which a resource originates
 - `labels` (String) List of lists of label URIs, encoded as a JSON string
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Rulesets to return. The integer should be a non-zero positive integer
 - `name` (String) Name of Ruleset(s) to return. Supports partial matches
 - `pversion` (String) pversion of the security policy. Allowed values are "draft", "active", and numbers greater than 0. Default value: "draft"

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -62,6 +62,7 @@ data "illumio-core_services" "windows_services" {
 - `description` (String) Long description of the Service
 - `external_data_reference` (String) External data reference identifier
 - `external_data_set` (String) External data set identifier
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Services to return. The integer should be a non-zero positive integer
 - `name` (String) Name of the Service (does not need to be unique)
 - `port` (String) Specify port or port range to filter results. The range is from -1 to 65535 (0 is not supported)

--- a/docs/data-sources/vens.md
+++ b/docs/data-sources/vens.md
@@ -35,6 +35,7 @@ data "illumio-core_vens" "example" {}
 - `last_goodbye_at_lte` (String) Greater than or equal to value for last goodbye at timestamp
 - `last_heartbeat_at_gte` (String) Greater than or equal to value for last heartbeat timestamp
 - `last_heartbeat_at_lte` (String) Less than or equal to value for last heartbeat timestamp
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of VENs to return. The integer should be a non-zero positive integer
 - `name` (String) Name of VEN(s) to return. Supports partial matches
 - `os` (String) Operating System of VEN(s) to return. Supports partial matches

--- a/docs/data-sources/virtual_services.md
+++ b/docs/data-sources/virtual_services.md
@@ -137,6 +137,7 @@ data "illumio-core_virtual_services" "au_qa_db" {
 - `external_data_reference` (String) A unique identifier within the external data source
 - `external_data_set` (String) The data source from which a resource originates
 - `labels` (String) List of lists of label URIs, encoded as a JSON string
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of Virtual Services to return. The integer should be a non-zero positive integer
 - `name` (String) Name on which to filter. Supports partial matches
 - `pversion` (String) pversion of the security policy. Allowed values are "draft", "active", and numbers greater than 0. Default value: "draft"

--- a/docs/data-sources/workloads.md
+++ b/docs/data-sources/workloads.md
@@ -146,6 +146,7 @@ data "illumio-core_workloads" "jenkins" {
 - `last_heartbeat_on_lte` (String) Less than or equal to value for last heartbeat on timestamp
 - `log_traffic` (String) Whether we want to log traffic events from this workload
 - `managed` (String) Return managed or unmanaged workloads using this filter
+- `match_type` (String) Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"
 - `max_results` (String) Maximum number of workloads to return. The integer should be a non-zero positive integer
 - `name` (String) Name of workload(s) to return. Supports partial matches
 - `online` (String) Return online/offline workloads using this filter

--- a/illumio-core/data_source_illumio_container_clusters_test.go
+++ b/illumio-core/data_source_illumio_container_clusters_test.go
@@ -12,26 +12,40 @@ import (
 
 var prefixCCL string = "TF-ACC-CCL"
 
+func init() {
+	resource.AddTestSweepers("container_clusters", &resource.Sweeper{
+		Name: "container_clusters",
+		F:    sweep("contain cluster", "name", prefixCCL, "/orgs/%d/container_clusters"),
+	})
+}
+
 func TestAccIllumioCCL_Read(t *testing.T) {
 	dataSourceName := "data.illumio-core_container_clusters.ccl_test"
+	ccName := acctest.RandomWithPrefix(prefixCCL)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIllumioCCLDataSourceConfig_basic(),
+				Config: testAccCheckIllumioCCLDataSourceConfig_basic(ccName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "items.#", "2"),
+				),
+			},
+			{
+				Config: testAccCheckIllumioCCLDataSourceConfig_exactMatch(ccName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "items.0.name", ccName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIllumioCCLDataSourceConfig_basic() string {
-	rName1 := acctest.RandomWithPrefix(prefixCCL)
-	rName2 := acctest.RandomWithPrefix(prefixCCL)
+func cclConfig(ccName string) string {
+	rName := acctest.RandomWithPrefix(prefixCCL)
 
 	return fmt.Sprintf(`
 resource "illumio-core_container_cluster" "ccl_test1" {
@@ -43,10 +57,14 @@ resource "illumio-core_container_cluster" "ccl_test2" {
 	name = %[2]q
 	description = "Terraform Container Cluster test"
 }
+`, rName, ccName)
+}
 
+func testAccCheckIllumioCCLDataSourceConfig_basic(ccName string) string {
+	return cclConfig(ccName) + fmt.Sprintf(`
 data "illumio-core_container_clusters" "ccl_test" {
 	# lookup based on partial match
-	name = %[3]q
+	name = %[1]q
 
 	# enforce dependencies
 	depends_on = [
@@ -54,5 +72,21 @@ data "illumio-core_container_clusters" "ccl_test" {
 		illumio-core_container_cluster.ccl_test2,
 	]
 }
-`, rName1, rName2, prefixCCL)
+`, prefixCCL)
+}
+
+func testAccCheckIllumioCCLDataSourceConfig_exactMatch(ccName string) string {
+	return cclConfig(ccName) + fmt.Sprintf(`
+data "illumio-core_container_clusters" "ccl_test" {
+	# lookup using exact match
+	name       = %[1]q
+	match_type = "exact"
+
+	# enforce dependencies
+	depends_on = [
+		illumio-core_container_cluster.ccl_test1,
+		illumio-core_container_cluster.ccl_test2,
+	]
+}
+`, ccName)
 }

--- a/illumio-core/data_source_illumio_ip_lists_test.go
+++ b/illumio-core/data_source_illumio_ip_lists_test.go
@@ -16,6 +16,11 @@ func init() {
 	resource.AddTestSweepers("ip_lists", &resource.Sweeper{
 		Name: "ip_lists",
 		F:    sweep("IP list", "name", prefixIPL, "/orgs/%d/sec_policy/draft/ip_lists"),
+		Dependencies: []string{
+			"enforcement_boundaries",
+			"rule_sets",
+			"virtual_services",
+		},
 	})
 }
 

--- a/illumio-core/data_source_illumio_ip_lists_test.go
+++ b/illumio-core/data_source_illumio_ip_lists_test.go
@@ -12,27 +12,41 @@ import (
 
 var prefixIPL string = "TF-ACC-IPL"
 
+func init() {
+	resource.AddTestSweepers("ip_lists", &resource.Sweeper{
+		Name: "ip_lists",
+		F:    sweep("IP list", "name", prefixIPL, "/orgs/%d/sec_policy/draft/ip_lists"),
+	})
+}
+
 func TestAccIllumioIPL_Read(t *testing.T) {
 	dataSourceName := "data.illumio-core_ip_lists.ipl_test"
+	ipListName := acctest.RandomWithPrefix(prefixIPL)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIllumioIPLDataSourceConfig_basic(),
+				Config: testAccCheckIllumioIPLDataSourceConfig_basic(ipListName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "items.#", "3"),
+				),
+			},
+			{
+				Config: testAccCheckIllumioIPLDataSourceConfig_exactMatch(ipListName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "items.0.name", ipListName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIllumioIPLDataSourceConfig_basic() string {
+func iplConfig(ipListName string) string {
 	rName1 := acctest.RandomWithPrefix(prefixIPL)
 	rName2 := acctest.RandomWithPrefix(prefixIPL)
-	rName3 := acctest.RandomWithPrefix(prefixIPL)
 
 	return fmt.Sprintf(`
 resource "illumio-core_ip_list" "ipl_test1" {
@@ -70,10 +84,14 @@ resource "illumio-core_ip_list" "ipl_test3" {
 		fqdn = "*.example.com"
 	}
 }
+`, rName1, rName2, ipListName)
+}
 
+func testAccCheckIllumioIPLDataSourceConfig_basic(ipListName string) string {
+	return iplConfig(ipListName) + fmt.Sprintf(`
 data "illumio-core_ip_lists" "ipl_test" {
 	# lookup based on partial match
-	name = %[4]q
+	name = %[1]q
 
 	# enforce dependencies
 	depends_on = [
@@ -82,5 +100,22 @@ data "illumio-core_ip_lists" "ipl_test" {
 		illumio-core_ip_list.ipl_test3,
 	]
 }
-`, rName1, rName2, rName3, prefixIPL)
+`, prefixIPL)
+}
+
+func testAccCheckIllumioIPLDataSourceConfig_exactMatch(ipListName string) string {
+	return iplConfig(ipListName) + fmt.Sprintf(`
+data "illumio-core_ip_lists" "ipl_test" {
+	# lookup using exact match
+	name       = %[1]q
+	match_type = "exact"
+
+	# enforce dependencies
+	depends_on = [
+		illumio-core_ip_list.ipl_test1,
+		illumio-core_ip_list.ipl_test2,
+		illumio-core_ip_list.ipl_test3,
+	]
+}
+`, ipListName)
 }

--- a/illumio-core/data_source_illumio_label_groups_test.go
+++ b/illumio-core/data_source_illumio_label_groups_test.go
@@ -16,6 +16,14 @@ func init() {
 	resource.AddTestSweepers("label_groups", &resource.Sweeper{
 		Name: "label_groups",
 		F:    sweep("label group", "name", prefixLGL, "/orgs/%d/sec_policy/draft/label_groups"),
+		Dependencies: []string{
+			"container_clusters",
+			"enforcement_boundaries",
+			"pairing_profiles",
+			"rule_sets",
+			"virtual_services",
+			"workloads",
+		},
 	})
 }
 

--- a/illumio-core/data_source_illumio_label_types_test.go
+++ b/illumio-core/data_source_illumio_label_types_test.go
@@ -14,8 +14,9 @@ var prefixLTL string = "TF-ACC-LTL"
 
 func init() {
 	resource.AddTestSweepers("label_types", &resource.Sweeper{
-		Name: "label_types",
-		F:    sweep("label type", "display_name", prefixLTL, "/orgs/%d/label_dimensions"),
+		Name:         "label_types",
+		F:            sweep("label type", "display_name", prefixLTL, "/orgs/%d/label_dimensions"),
+		Dependencies: []string{"labels"},
 	})
 }
 

--- a/illumio-core/data_source_illumio_label_types_test.go
+++ b/illumio-core/data_source_illumio_label_types_test.go
@@ -12,26 +12,40 @@ import (
 
 var prefixLTL string = "TF-ACC-LTL"
 
+func init() {
+	resource.AddTestSweepers("label_types", &resource.Sweeper{
+		Name: "label_types",
+		F:    sweep("label type", "display_name", prefixLTL, "/orgs/%d/label_dimensions"),
+	})
+}
+
 func TestAccIllumioLTL_Read(t *testing.T) {
 	dataSourceName := "data.illumio-core_label_types.ltl_test"
+	labelTypeName := acctest.RandomWithPrefix(prefixLTL)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIllumioLTLDataSourceConfig_basic(),
+				Config: testAccCheckIllumioLTLDataSourceConfig_basic(labelTypeName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "items.#", "2"),
+				),
+			},
+			{
+				Config: testAccCheckIllumioLTLDataSourceConfig_exactMatch(labelTypeName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "items.0.display_name", labelTypeName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIllumioLTLDataSourceConfig_basic() string {
-	rName1 := acctest.RandomWithPrefix(prefixLTL)
-	rName2 := acctest.RandomWithPrefix(prefixLTL)
+func ltlConfig(labelTypeName string) string {
+	rName := acctest.RandomWithPrefix(prefixLTL)
 
 	return fmt.Sprintf(`
 resource "illumio-core_label_type" "ltl_test1" {
@@ -43,10 +57,14 @@ resource "illumio-core_label_type" "ltl_test2" {
 	key          = %[2]q
 	display_name = %[2]q
 }
+`, rName, labelTypeName)
+}
 
+func testAccCheckIllumioLTLDataSourceConfig_basic(labelTypeName string) string {
+	return ltlConfig(labelTypeName) + fmt.Sprintf(`
 data "illumio-core_label_types" "ltl_test" {
 	# lookup based on partial match
-	display_name = %[3]q
+	display_name = %[1]q
 
 	# enforce dependencies
 	depends_on = [
@@ -54,5 +72,21 @@ data "illumio-core_label_types" "ltl_test" {
 		illumio-core_label_type.ltl_test2,
 	]
 }
-`, rName1, rName2, prefixLTL)
+`, prefixLTL)
+}
+
+func testAccCheckIllumioLTLDataSourceConfig_exactMatch(labelTypeName string) string {
+	return ltlConfig(labelTypeName) + fmt.Sprintf(`
+data "illumio-core_label_types" "ltl_test" {
+	# lookup using exact match
+	display_name = %[1]q
+	match_type   = "exact"
+
+	# enforce dependencies
+	depends_on = [
+		illumio-core_label_type.ltl_test1,
+		illumio-core_label_type.ltl_test2,
+	]
+}
+`, labelTypeName)
 }

--- a/illumio-core/data_source_illumio_labels_test.go
+++ b/illumio-core/data_source_illumio_labels_test.go
@@ -16,6 +16,15 @@ func init() {
 	resource.AddTestSweepers("labels", &resource.Sweeper{
 		Name: "labels",
 		F:    sweep("label", "value", prefixLL, "/orgs/%d/labels"),
+		Dependencies: []string{
+			"container_clusters",
+			"enforcement_boundaries",
+			"label_groups",
+			"pairing_profiles",
+			"rule_sets",
+			"virtual_services",
+			"workloads",
+		},
 	})
 }
 

--- a/illumio-core/data_source_illumio_pairing_profiles.go
+++ b/illumio-core/data_source_illumio_pairing_profiles.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func datasourceIllumioPairingProfiles() *schema.Resource {
@@ -230,6 +231,13 @@ func datasourceIllumioPairingProfiles() *schema.Resource {
 				Optional:    true,
 				Description: "Name of Pairing Profile(s) to return. Supports partial matches",
 			},
+			"match_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      PARTIAL_MATCH,
+				ValidateFunc: validation.StringInSlice([]string{PARTIAL_MATCH, EXACT_MATCH}, true),
+				Description:  `Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"`,
+			},
 		},
 	}
 }
@@ -295,6 +303,13 @@ func dataSourceIllumioPairingProfilesRead(ctx context.Context, d *schema.Resourc
 	pps := []map[string]interface{}{}
 
 	for _, child := range data.Children() {
+		// if exact matching is enabled, skip the object if it's a partial match
+		if d.Get("match_type").(string) == EXACT_MATCH {
+			if !isExactMatch("name", d, child) {
+				continue
+			}
+		}
+
 		pp := extractMap(child, ppKeys)
 
 		key := "labels"

--- a/illumio-core/data_source_illumio_pairing_profiles_test.go
+++ b/illumio-core/data_source_illumio_pairing_profiles_test.go
@@ -12,26 +12,40 @@ import (
 
 var prefixPPL string = "TF-ACC-PPL"
 
+func init() {
+	resource.AddTestSweepers("pairing_profiles", &resource.Sweeper{
+		Name: "pairing_profiles",
+		F:    sweep("pairing profile", "name", prefixPPL, "/orgs/%d/pairing_profiles"),
+	})
+}
+
 func TestAccIllumioPPL_Read(t *testing.T) {
 	dataSourceName := "data.illumio-core_pairing_profiles.ppl_test"
+	profileName := acctest.RandomWithPrefix(prefixPPL)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIllumioPPLDataSourceConfig_basic(),
+				Config: testAccCheckIllumioPPLDataSourceConfig_basic(profileName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "items.#", "2"),
+				),
+			},
+			{
+				Config: testAccCheckIllumioPPLDataSourceConfig_exactMatch(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "items.0.name", profileName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIllumioPPLDataSourceConfig_basic() string {
-	rName1 := acctest.RandomWithPrefix(prefixPPL)
-	rName2 := acctest.RandomWithPrefix(prefixPPL)
+func pplConfig(profileName string) string {
+	rName := acctest.RandomWithPrefix(prefixPPL)
 
 	return fmt.Sprintf(`
 resource "illumio-core_pairing_profile" "ppl_test1" {
@@ -65,10 +79,14 @@ resource "illumio-core_pairing_profile" "ppl_test2" {
 	visibility_level_lock = false
 	enforcement_mode      = "visibility_only"
 }
+`, rName, profileName)
+}
 
+func testAccCheckIllumioPPLDataSourceConfig_basic(profileName string) string {
+	return pplConfig(profileName) + fmt.Sprintf(`
 data "illumio-core_pairing_profiles" "ppl_test" {
 	# lookup based on partial match
-	name = %[3]q
+	name = %[1]q
 
 	# enforce dependencies
 	depends_on = [
@@ -76,5 +94,21 @@ data "illumio-core_pairing_profiles" "ppl_test" {
 		illumio-core_pairing_profile.ppl_test2,
 	]
 }
-`, rName1, rName2, prefixPPL)
+`, prefixPPL)
+}
+
+func testAccCheckIllumioPPLDataSourceConfig_exactMatch(profileName string) string {
+	return pplConfig(profileName) + fmt.Sprintf(`
+data "illumio-core_pairing_profiles" "ppl_test" {
+	# lookup using exact match
+	name       = %[1]q
+	match_type = "exact"
+
+	# enforce dependencies
+	depends_on = [
+		illumio-core_pairing_profile.ppl_test1,
+		illumio-core_pairing_profile.ppl_test2,
+	]
+}
+`, profileName)
 }

--- a/illumio-core/data_source_illumio_rule_sets_test.go
+++ b/illumio-core/data_source_illumio_rule_sets_test.go
@@ -15,29 +15,7 @@ var prefixRSL string = "TF-ACC-RSL"
 func init() {
 	resource.AddTestSweepers("rule_sets", &resource.Sweeper{
 		Name: "rule_sets",
-		F: func(region string) error {
-			conf := TestAccProvider.Meta().(Config)
-			illumioClient := conf.IllumioClient
-
-			endpoint := fmt.Sprintf("/orgs/%d/sec_policy/draft/rule_sets", illumioClient.OrgID)
-			_, data, err := illumioClient.Get(endpoint, &map[string]string{
-				"name": prefixWLL,
-			})
-
-			if err != nil {
-				return fmt.Errorf("Error getting rule sets: %s", err)
-			}
-
-			for _, ruleSet := range data.Children() {
-				href := ruleSet.S("href").Data().(string)
-				_, err := illumioClient.Delete(href)
-				if err != nil {
-					fmt.Printf("Failed to sweep rule set with HREF: %s", href)
-				}
-			}
-
-			return nil
-		},
+		F:    sweep("rule set", "name", prefixRSL, "/orgs/%d/sec_policy/draft/rule_sets"),
 	})
 }
 

--- a/illumio-core/data_source_illumio_services_test.go
+++ b/illumio-core/data_source_illumio_services_test.go
@@ -16,6 +16,12 @@ func init() {
 	resource.AddTestSweepers("services", &resource.Sweeper{
 		Name: "services",
 		F:    sweep("service", "name", prefixSL, "/orgs/%d/sec_policy/draft/services"),
+		Dependencies: []string{
+			"enforcement_boundaries",
+			"rule_sets",
+			"virtual_services",
+			"workloads",
+		},
 	})
 }
 

--- a/illumio-core/data_source_illumio_services_test.go
+++ b/illumio-core/data_source_illumio_services_test.go
@@ -12,26 +12,40 @@ import (
 
 var prefixSL string = "TF-ACC-SL"
 
+func init() {
+	resource.AddTestSweepers("services", &resource.Sweeper{
+		Name: "services",
+		F:    sweep("service", "name", prefixVSL, "/orgs/%d/sec_policy/draft/services"),
+	})
+}
+
 func TestAccIllumioSL_Read(t *testing.T) {
 	dataSourceName := "data.illumio-core_services.sl_test"
+	serviceName := acctest.RandomWithPrefix(prefixSL)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIllumioSLDataSourceConfig_basic(),
+				Config: testAccCheckIllumioSLDataSourceConfig_basic(serviceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "items.#", "2"),
+				),
+			},
+			{
+				Config: testAccCheckIllumioSLDataSourceConfig_exactMatch(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "items.0.name", serviceName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIllumioSLDataSourceConfig_basic() string {
-	rName1 := acctest.RandomWithPrefix(prefixSL)
-	rName2 := acctest.RandomWithPrefix(prefixSL)
+func slConfig(serviceName string) string {
+	rName := acctest.RandomWithPrefix(prefixSL)
 
 	return fmt.Sprintf(`
 resource "illumio-core_service" "sl_test1" {
@@ -63,10 +77,14 @@ resource "illumio-core_service" "sl_test2" {
 		port = 138
 	}
 }
+`, rName, serviceName)
+}
 
+func testAccCheckIllumioSLDataSourceConfig_basic(serviceName string) string {
+	return slConfig(serviceName) + fmt.Sprintf(`
 data "illumio-core_services" "sl_test" {
 	# lookup based on partial match
-	name = %[3]q
+	name = %[1]q
 
 	# enforce dependencies
 	depends_on = [
@@ -74,5 +92,21 @@ data "illumio-core_services" "sl_test" {
 		illumio-core_service.sl_test2,
 	]
 }
-`, rName1, rName2, prefixSL)
+`, prefixSL)
+}
+
+func testAccCheckIllumioSLDataSourceConfig_exactMatch(serviceName string) string {
+	return slConfig(serviceName) + fmt.Sprintf(`
+data "illumio-core_services" "sl_test" {
+	# lookup using exact match
+	name       = %[1]q
+	match_type = "exact"
+
+	# enforce dependencies
+	depends_on = [
+		illumio-core_service.sl_test1,
+		illumio-core_service.sl_test2,
+	]
+}
+`, serviceName)
 }

--- a/illumio-core/data_source_illumio_services_test.go
+++ b/illumio-core/data_source_illumio_services_test.go
@@ -15,7 +15,7 @@ var prefixSL string = "TF-ACC-SL"
 func init() {
 	resource.AddTestSweepers("services", &resource.Sweeper{
 		Name: "services",
-		F:    sweep("service", "name", prefixVSL, "/orgs/%d/sec_policy/draft/services"),
+		F:    sweep("service", "name", prefixSL, "/orgs/%d/sec_policy/draft/services"),
 	})
 }
 

--- a/illumio-core/data_source_illumio_virtual_services.go
+++ b/illumio-core/data_source_illumio_virtual_services.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func datasourceIllumioVirtualServices() *schema.Resource {
@@ -287,6 +288,13 @@ func datasourceIllumioVirtualServices() *schema.Resource {
 				ValidateDiagFunc: isStringABoolean(),
 				Description:      "Include Virtual Service usage flags",
 			},
+			"match_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      PARTIAL_MATCH,
+				ValidateFunc: validation.StringInSlice([]string{PARTIAL_MATCH, EXACT_MATCH}, true),
+				Description:  `Indicates whether to return all partially-matching names or only exact matches. Allowed values are "partial" and "exact". Default value: "partial"`,
+			},
 		},
 	}
 }
@@ -352,6 +360,13 @@ func dataSourceIllumioVirtualServicesRead(ctx context.Context, d *schema.Resourc
 	}
 
 	for _, child := range data.Children() {
+		// if exact matching is enabled, skip the object if it's a partial match
+		if d.Get("match_type").(string) == EXACT_MATCH {
+			if !isExactMatch("name", d, child) {
+				continue
+			}
+		}
+
 		m := extractMap(child, keys)
 
 		key := "service"

--- a/illumio-core/data_source_illumio_virtual_services_test.go
+++ b/illumio-core/data_source_illumio_virtual_services_test.go
@@ -16,6 +16,10 @@ func init() {
 	resource.AddTestSweepers("virtual_services", &resource.Sweeper{
 		Name: "virtual_services",
 		F:    sweep("virtual service", "name", prefixVSL, "/orgs/%d/sec_policy/draft/virtual_services"),
+		Dependencies: []string{
+			"enforcement_boundaries",
+			"rule_sets",
+		},
 	})
 }
 

--- a/illumio-core/data_source_illumio_workloads_test.go
+++ b/illumio-core/data_source_illumio_workloads_test.go
@@ -15,29 +15,7 @@ var prefixWLL string = "TF-ACC-WLL"
 func init() {
 	resource.AddTestSweepers("workloads", &resource.Sweeper{
 		Name: "workloads",
-		F: func(region string) error {
-			conf := TestAccProvider.Meta().(Config)
-			illumioClient := conf.IllumioClient
-
-			endpoint := fmt.Sprintf("/orgs/%d/workloads", illumioClient.OrgID)
-			_, data, err := illumioClient.Get(endpoint, &map[string]string{
-				"name": prefixWLL,
-			})
-
-			if err != nil {
-				return fmt.Errorf("Error getting workloads: %s", err)
-			}
-
-			for _, workload := range data.Children() {
-				href := workload.S("href").Data().(string)
-				_, err := illumioClient.Delete(href)
-				if err != nil {
-					fmt.Printf("Failed to sweep workload with HREF: %s", href)
-				}
-			}
-
-			return nil
-		},
+		F:    sweep("workload", "name", prefixWLL, "/orgs/%d/workloads"),
 	})
 }
 

--- a/illumio-core/data_source_illumio_workloads_test.go
+++ b/illumio-core/data_source_illumio_workloads_test.go
@@ -12,26 +12,62 @@ import (
 
 var prefixWLL string = "TF-ACC-WLL"
 
+func init() {
+	resource.AddTestSweepers("workloads", &resource.Sweeper{
+		Name: "workloads",
+		F: func(region string) error {
+			conf := TestAccProvider.Meta().(Config)
+			illumioClient := conf.IllumioClient
+
+			endpoint := fmt.Sprintf("/orgs/%d/workloads", illumioClient.OrgID)
+			_, data, err := illumioClient.Get(endpoint, &map[string]string{
+				"name": prefixWLL,
+			})
+
+			if err != nil {
+				return fmt.Errorf("Error getting workloads: %s", err)
+			}
+
+			for _, workload := range data.Children() {
+				href := workload.S("href").Data().(string)
+				_, err := illumioClient.Delete(href)
+				if err != nil {
+					fmt.Printf("Failed to sweep workload with HREF: %s", href)
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
 func TestAccIllumioWLL_Read(t *testing.T) {
 	dataSourceName := "data.illumio-core_workloads.wll"
+	workloadName := acctest.RandomWithPrefix(prefixWLL)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIllumioWLLDataSourceConfig_basic(),
+				Config: testAccCheckIllumioWLLDataSourceConfig_basic(workloadName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "items.#", "2"),
+				),
+			},
+			{
+				Config: testAccCheckIllumioWLLDataSourceConfig_exactMatch(workloadName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "items.0.name", workloadName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIllumioWLLDataSourceConfig_basic() string {
-	rName1 := acctest.RandomWithPrefix(prefixWLL)
-	rName2 := acctest.RandomWithPrefix(prefixWLL)
+func wllConfig(workloadName string) string {
+	rName := acctest.RandomWithPrefix(prefixWLL)
 
 	return fmt.Sprintf(`
 resource "illumio-core_unmanaged_workload" "wll1" {
@@ -45,9 +81,13 @@ resource "illumio-core_unmanaged_workload" "wll2" {
 	description        = "Terraform Workloads test 2"
 	hostname           = "jumpbox2"
 }
+`, rName, workloadName)
+}
 
+func testAccCheckIllumioWLLDataSourceConfig_basic(workloadName string) string {
+	return wllConfig(workloadName) + fmt.Sprintf(`
 data "illumio-core_workloads" "wll" {
-	name = %[3]q
+	name = %[1]q
 
 	# enforce dependencies
 	depends_on = [
@@ -55,5 +95,20 @@ data "illumio-core_workloads" "wll" {
 		illumio-core_unmanaged_workload.wll2,
 	]
 }
-`, rName1, rName2, prefixWLL)
+`, prefixWLL)
+}
+
+func testAccCheckIllumioWLLDataSourceConfig_exactMatch(workloadName string) string {
+	return wllConfig(workloadName) + fmt.Sprintf(`
+data "illumio-core_workloads" "wll" {
+	name       = %[1]q
+	match_type = "exact"
+
+	# enforce dependencies
+	depends_on = [
+		illumio-core_unmanaged_workload.wll1,
+		illumio-core_unmanaged_workload.wll2,
+	]
+}
+`, workloadName)
 }

--- a/illumio-core/illumio_sweeper_test.go
+++ b/illumio-core/illumio_sweeper_test.go
@@ -79,7 +79,7 @@ func sweep(objectType, matchKey, prefix, endpoint string) resource.SweeperFunc {
 			href := o.S("href").Data().(string)
 			_, err := illumioClient.Delete(href)
 			if err != nil {
-				fmt.Printf("Failed to sweep %s with HREF: %s", objectType, href)
+				fmt.Printf("Failed to sweep %s with HREF %s: %s\n", objectType, href, err)
 			}
 		}
 

--- a/illumio-core/illumio_sweeper_test.go
+++ b/illumio-core/illumio_sweeper_test.go
@@ -1,0 +1,87 @@
+package illumiocore
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/illumio/terraform-provider-illumio-core/client"
+	"golang.org/x/time/rate"
+)
+
+// TestMain parses test flags and invokes sweepers
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func sharedClient(r string) (*client.V2, error) {
+	pceHost := os.Getenv("ILLUMIO_PCE_HOST")
+	if pceHost == "" {
+		return nil, fmt.Errorf("ILLUMIO_PCE_HOST environment variable must be set.")
+	}
+
+	orgID, err := strconv.Atoi(os.Getenv("ILLUMIO_PCE_ORG_ID"))
+	if err != nil {
+		orgID = 1
+	}
+
+	apiKeyUsername := os.Getenv("ILLUMIO_API_KEY_USERNAME")
+	if apiKeyUsername == "" {
+		return nil, fmt.Errorf("ILLUMIO_API_KEY_USERNAME environment variable must be set.")
+	}
+
+	apiKeySecret := os.Getenv("ILLUMIO_API_KEY_SECRET")
+	if apiKeySecret == "" {
+		return nil, fmt.Errorf("ILLUMIO_API_KEY_SECRET environment variable must be set.")
+	}
+
+	insecure := false
+	if os.Getenv("ILLUMIO_ALLOW_INSECURE_TLS") == "yes" {
+		insecure = true
+	}
+
+	return client.NewV2(
+		pceHost,
+		orgID,
+		apiKeyUsername,
+		apiKeySecret,
+		30,
+		rate.NewLimiter(rate.Limit(float64(125)/float64(60)), 1), // limits API calls 125/min
+		10,
+		3,
+		insecure,
+		os.Getenv("ILLUMIO_CA_FILE"),
+		os.Getenv("ILLUMIO_PROXY_URL"),
+		os.Getenv("ILLUMIO_PROXY_CREDENTIALS"),
+	)
+}
+
+func sweep(objectType, matchKey, prefix, endpoint string) resource.SweeperFunc {
+	return func(r string) error {
+		illumioClient, err := sharedClient(r)
+		if err != nil {
+			return fmt.Errorf("Error creating Illumio client for sweepers: %s", err)
+		}
+
+		endpoint = fmt.Sprintf(endpoint, illumioClient.OrgID)
+		_, data, err := illumioClient.Get(endpoint, &map[string]string{
+			matchKey: prefix,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error fetching objects for %s sweeper: %s", objectType, err)
+		}
+
+		for _, o := range data.Children() {
+			href := o.S("href").Data().(string)
+			_, err := illumioClient.Delete(href)
+			if err != nil {
+				fmt.Printf("Failed to sweep %s with HREF: %s", objectType, href)
+			}
+		}
+
+		return nil
+	}
+}

--- a/illumio-core/illumio_sweeper_test.go
+++ b/illumio-core/illumio_sweeper_test.go
@@ -74,6 +74,7 @@ func sweep(objectType, matchKey, prefix, endpoint string) resource.SweeperFunc {
 			return fmt.Errorf("Error fetching objects for %s sweeper: %s", objectType, err)
 		}
 
+		// XXX: currently this will not remove objects that have been provisioned
 		for _, o := range data.Children() {
 			href := o.S("href").Data().(string)
 			_, err := illumioClient.Delete(href)

--- a/illumio-core/utils.go
+++ b/illumio-core/utils.go
@@ -79,7 +79,9 @@ const (
 	UUID_V4_REGEX               = "[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}"
 	ORGS_PREFIX                 = "^/orgs/[1-9][0-9]*/"
 	SEC_POLICY_PREFIX           = "sec_policy/(draft|active|[0-9]*)/"
-	PORT_MAX                    = 65535
+	EXACT_MATCH                 = "exact"
+	PARTIAL_MATCH               = "partial"
+	PORT_MAX             int    = 65535
 )
 
 var (
@@ -401,6 +403,10 @@ func extractResourceScopes(data *gabs.Container) []map[string]interface{} {
 		ms = append(ms, m)
 	}
 	return ms
+}
+
+func isExactMatch(key string, d *schema.ResourceData, o *gabs.Container) bool {
+	return o.S(key).Data().(string) == d.Get(key).(string)
 }
 
 func paramsString(p map[string]string) string {


### PR DESCRIPTION
* #46 - Add a `match_type` parameter to plural data resources to allow users to specify exact name/value matching.
* Add tests for exact name matching
* Add sweepers to remove leaked resources from acceptance test runs