### PR TITLE
Normalize ip_ranges

### DIFF
--- a/illumio-core/data_source_illumio_ip_list_test.go
+++ b/illumio-core/data_source_illumio_ip_list_test.go
@@ -110,7 +110,7 @@ resource "illumio-core_ip_list" "ip_test" {
 `, ipListName)
 }
 
-func testAccCheckIllumioIPResource_IPRangeConsolidation(ipListName string) string {
+func testAccCheckIllumioIPResource_IPRangeNormalization(ipListName string) string {
 	return fmt.Sprintf(`
 resource "illumio-core_ip_list" "ip_test" {
 	name        = %[1]q
@@ -126,7 +126,7 @@ resource "illumio-core_ip_list" "ip_test" {
 		description = ""
 		exclusion = false
 	}
-	# test consolidation of identical subnets
+	# test merger of identical subnets
 	# and change to network address
 	ip_ranges {
 		from_ip = "10.1.0.10/14"
@@ -138,6 +138,9 @@ resource "illumio-core_ip_list" "ip_test" {
 		description = ""
 		exclusion = false
 	}
+	# test that duplicate subnets with
+	# different description/exclusion
+	# fields are retained
 	ip_ranges {
 		from_ip = "10.0.0.10/14"
 		description = "test desc"

--- a/illumio-core/data_source_illumio_ip_list_test.go
+++ b/illumio-core/data_source_illumio_ip_list_test.go
@@ -40,6 +40,17 @@ func TestAccIllumioIP_Read(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccCheckIllumioIPResource_IPRangeConsolidation(ipListName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "5"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_ranges.*", map[string]string{"from_ip": "10.1.0.0"}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_ranges.*", map[string]string{"from_ip": "2001:4860:4860::8844"}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_ranges.*", map[string]string{"from_ip": "10.0.0.0/14", "description": "", "exclusion": "false"}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_ranges.*", map[string]string{"from_ip": "10.0.0.0/14", "description": "test desc", "exclusion": "false"}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_ranges.*", map[string]string{"from_ip": "10.0.0.0/14", "description": "", "exclusion": "true"}),
+				),
+			},
+			{
 				Config: testAccCheckIllumioIPResource_removeIPRanges(ipListName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "0"),
@@ -91,6 +102,51 @@ resource "illumio-core_ip_list" "ip_test" {
 		from_ip = "10.1.0.0/16"
 		description = ""
 		exclusion = false
+	}
+	fqdns {
+		fqdn = "app.example.com"
+	}
+}
+`, ipListName)
+}
+
+func testAccCheckIllumioIPResource_IPRangeConsolidation(ipListName string) string {
+	return fmt.Sprintf(`
+resource "illumio-core_ip_list" "ip_test" {
+	name        = %[1]q
+	description = "Terraform IP List test"
+	# test CIDR notation strip for individual address ranges
+	ip_ranges {
+		from_ip = "10.1.0.0/32"
+		description = ""
+		exclusion = false
+	}
+	ip_ranges {
+		from_ip = "2001:4860:4860::8844/128"
+		description = ""
+		exclusion = false
+	}
+	# test consolidation of identical subnets
+	# and change to network address
+	ip_ranges {
+		from_ip = "10.1.0.10/14"
+		description = ""
+		exclusion = false
+	}
+	ip_ranges {
+		from_ip = "10.0.0.10/14"
+		description = ""
+		exclusion = false
+	}
+	ip_ranges {
+		from_ip = "10.0.0.10/14"
+		description = "test desc"
+		exclusion = false
+	}
+	ip_ranges {
+		from_ip = "10.0.0.10/14"
+		description = ""
+		exclusion = true
 	}
 	fqdns {
 		fqdn = "app.example.com"


### PR DESCRIPTION
The PCE automatically normalizes CIDR notation IP ranges using the following rules:
* Single-address ranges (/32 and /128) are stripped of their CIDR notation
* CIDR ranges have host bits stripped (address is changed to the subnet network address)
* Identical subnets are merged

This behaviour is now replicated by the `ip_list` resource to avoid always having a plan diff for resources updated by the above process.

* normalize ip_ranges on create/update to avoid discrepancy between HCL and PCE from_ip values for some CIDR notation ranges