### PR TITLE
Fix Null Errors with Empty State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.6 (TBD)
+
+BUG FIXES:
+
+* Fix errors caused by customdiff functions when plan/apply is run with a null state on the following resources:
+    * `illumio-core_ip_list`
+    * `illumio-core_container_cluster_workload_profile`
+
 ## 1.1.5 (Dec 7, 2023)
 
 ENHANCEMENTS:

--- a/illumio-core/resource_illumio_container_cluster_workload_profile.go
+++ b/illumio-core/resource_illumio_container_cluster_workload_profile.go
@@ -229,6 +229,10 @@ func customizeAssignedLabels() schema.CustomizeDiffFunc {
 }
 
 func assignedLabelsRemoved(conf cty.Value, state cty.Value) bool {
+	if conf.IsNull() || state.IsNull() {
+		return false
+	}
+
 	confMap := conf.AsValueMap()
 
 	if assignLabels, ok := confMap["assign_labels"]; ok {

--- a/illumio-core/resource_illumio_ip_list.go
+++ b/illumio-core/resource_illumio_ip_list.go
@@ -188,6 +188,10 @@ func customizeIPRanges() schema.CustomizeDiffFunc {
 }
 
 func ipRangesRemoved(conf cty.Value, state cty.Value) bool {
+	if conf.IsNull() || state.IsNull() {
+		return false
+	}
+
 	confMap := conf.AsValueMap()
 
 	if ipranges, ok := confMap["ip_ranges"]; ok {


### PR DESCRIPTION
Fix errors caused by customdiff functions when plan/apply is run with a null state on the following resources:
    * `illumio-core_ip_list`
    * `illumio-core_container_cluster_workload_profile`
